### PR TITLE
Custom Tabs doesn't close on redirecting back to app scheme 

### DIFF
--- a/android/src/main/java/com/github/droibit/android/reactnative/customtabs/CustomTabsModule.java
+++ b/android/src/main/java/com/github/droibit/android/reactnative/customtabs/CustomTabsModule.java
@@ -3,6 +3,7 @@ package com.github.droibit.android.reactnative.customtabs;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
+import android.content.Intent;
 import android.os.Bundle;
 import android.provider.Browser;
 import android.support.customtabs.CustomTabsIntent;
@@ -159,6 +160,8 @@ public class CustomTabsModule extends ReactContextBaseJavaModule {
             }
         }
         CustomTabsIntent customTabsIntent = builder.build();
+        customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+        customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
         // Add custom headers if present
         if (option.hasKey(KEY_HEADERS)) {


### PR DESCRIPTION
First off, this code is not ready as an actual fix. Its to show how I fixed my problem.
Its based [off this SO post](https://stackoverflow.com/questions/43318400/chrome-custom-tabs-does-not-closes-on-redirection)

My case:
1) Open Custom Tabs to an Oauth sign-in flow.
2) After sign-in, the auth-site sends a final 302 redirect to myapp://signed_in

Problem:
Custom tabs doesn't close and go back to my app, leaving the user with a blank browser screen.

By adding these flags it worked as expected.

I'm not an android or java developer, I'm not even sure what these flags mean. 
But maybe extend the option-flags to include this somehow?
