### PR TITLE
ios: Fix build with RN v0.39 and below

### DIFF
--- a/ios/ReactNativeCustomTabs/DBChromeManager.h
+++ b/ios/ReactNativeCustomTabs/DBChromeManager.h
@@ -6,7 +6,11 @@
 //  Copyright © 2016 Facebook. All rights reserved.
 //
 
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
+#endif
 
 @interface DBChromeManager : NSObject<RCTBridgeModule>
 

--- a/ios/ReactNativeCustomTabs/DBChromeManager.m
+++ b/ios/ReactNativeCustomTabs/DBChromeManager.m
@@ -6,7 +6,11 @@
 //  Copyright © 2016 Facebook. All rights reserved.
 //
 
+#if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
+#else
+#import "RCTUtils.h"
+#endif
 #import "DBChromeManager.h"
 
 @implementation DBChromeManager


### PR DESCRIPTION
This maintains forward compatibility.

Note that this pattern of conditional header imports are used in other packages, such as [react-native-sentry](https://github.com/getsentry/react-native-sentry/blob/master/ios/RNSentry.h)