### PR TITLE
Demonstrate CustomTabs import in readme JS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ dependencies {
 Open the URL as `Linking` of React Native.
 
 ```javascript
+import { CustomTabs } from 'react-native-custom-tabs';
+
 CustomTabs.openURL('https://www.google.com').then((launched: {boolean}) => {
   console.log(`Launched custom tabs: ${launched}`);
 }).catch(err => {


### PR DESCRIPTION
Hi, and thanks for the useful library!

The JS usage example in readme doesn't currently show how to import `CustomTabs` from the module (i.e. default vs named import). This information is relevant to anyone using the library.

This PR adds the import statement to the JS example.