### PR TITLE
Migrated build.gradle to accept project-wide properties

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,20 +1,22 @@
 apply plugin: "com.android.library"
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 25)
+    buildToolsVersion safeExtGet('buildToolsVersion', "25.0.1")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 27)
     }
 }
 
 dependencies {
     compile "com.facebook.react:react-native:+"  // From node_modules
-    compile 'com.android.support:customtabs:25.0.1'
+    compile "com.android.support:customtabs:${safeExtGet('supportLibVersion', '25.0.1')}"
     compile ('com.github.droibit.customtabslauncher:launcher:1.0.8') {
         exclude module: 'customtabs'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,11 +15,11 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"  // From node_modules
-    compile "com.android.support:customtabs:${safeExtGet('supportLibVersion', '25.0.1')}"
-    compile ('com.github.droibit.customtabslauncher:launcher:1.0.8') {
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "com.android.support:customtabs:${safeExtGet('supportLibVersion', '25.0.1')}"
+    implementation ('com.github.droibit.customtabslauncher:launcher:1.0.8') {
         exclude module: 'customtabs'
     }
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
It is recommended to write the library to accept [project wide properties](https://developer.android.com/studio/build/gradle-tips.html).
Also replaced `compile` statements with `implementation` because [it's deprecated](https://stackoverflow.com/a/44419574/8258437)